### PR TITLE
Fix deprecated upload-artifact action by upgrading to v4

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,7 +68,7 @@ jobs:
         name: codecov-umbrella
         
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-reports


### PR DESCRIPTION
### Summary

This PR upgrades `actions/upload-artifact` from `v3` to `v4` in the GitHub Actions workflow. The previous version was deprecated and has now been disabled by GitHub as of June 2024.

### Why the change?

GitHub officially deprecated `upload-artifact@v3`:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Without this update, the CI pipeline fails with the following error:
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

### Changes Made
- Replaced `actions/upload-artifact@v3` with `actions/upload-artifact@v4` in the `test` job.

### Impact
- Fixes CI failure caused by deprecated action.
- No changes to logic or functionality—just a version bump for compatibility.

---

Let me know if you'd like to pin the action to a specific version or SHA for extra stability.
